### PR TITLE
Easier indexing of UObject properties

### DIFF
--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/JsonSerializer.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/JsonSerializer.kt
@@ -82,7 +82,7 @@ object JsonSerializer {
             is FLinearColor -> jsonObject("R" to ob.r, "G" to ob.g, "B" to ob.b, "A" to ob.a)
             is FStructFallback -> {
                 val jsOb = JsonObject()
-                ob.properties.forEach { jsOb[it.name.text] = it.prop!!.toJson(context) }
+                ob.properties.forEach { jsOb[it.key.text] = it.value.prop!!.toJson(context) }
                 jsOb
             }
             is FVector2D -> jsonObject("X" to ob.x, "Y" to ob.y)

--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UCurveTable.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UCurveTable.kt
@@ -63,7 +63,7 @@ class UCurveTable : UObject() {
                 ECurveTableMode.SimpleCurves -> FSimpleCurve()
                 ECurveTableMode.RichCurves -> FRichCurve()
             }.apply {
-                val properties = mutableListOf<FPropertyTag>()
+                val properties = linkedMapOf<FName, FPropertyTag>()
                 if (Ar.useUnversionedPropertySerialization) {
                     deserializeUnversionedProperties(properties, rowStruct, Ar)
                 } else {

--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UDataTable.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UDataTable.kt
@@ -31,7 +31,7 @@ open class UDataTable : UObject {
         super.deserialize(Ar, validPos)
         rows = Ar.readTMap {
             val key = Ar.readFName()
-            val rowProperties = mutableListOf<FPropertyTag>()
+            val rowProperties = linkedMapOf<FName, FPropertyTag>()
             if (Ar.useUnversionedPropertySerialization) {
                 deserializeUnversionedProperties(rowProperties, RowStruct!!.value, Ar)
             } else {

--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UserDefinedStruct.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/exports/UserDefinedStruct.kt
@@ -4,6 +4,7 @@ import me.fungames.jfortniteparse.ue4.assets.objects.FPropertyTag
 import me.fungames.jfortniteparse.ue4.assets.reader.FAssetArchive
 import me.fungames.jfortniteparse.ue4.objects.core.misc.FGuid
 import me.fungames.jfortniteparse.ue4.objects.uobject.EObjectFlags
+import me.fungames.jfortniteparse.ue4.objects.uobject.FName
 import me.fungames.jfortniteparse.ue4.objects.uobject.serialization.deserializeUnversionedProperties
 
 enum class EUserDefinedStructureStatus {
@@ -28,7 +29,7 @@ class UUserDefinedStruct : UScriptStruct() {
         }
         if (false && EUserDefinedStructureStatus.UDSS_UpToDate == Status) {
             // UScriptStruct::SerializeItem
-            val defaultProperties = mutableListOf<FPropertyTag>() // TODO should we save this?
+            val defaultProperties = linkedMapOf<FName, FPropertyTag>() // TODO should we save this?
             if (Ar.useUnversionedPropertySerialization) {
                 deserializeUnversionedProperties(defaultProperties, this, Ar)
             } else {

--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/objects/IPropertyHolder.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/objects/IPropertyHolder.kt
@@ -1,5 +1,7 @@
 package me.fungames.jfortniteparse.ue4.assets.objects
 
+import me.fungames.jfortniteparse.ue4.objects.uobject.FName
+
 interface IPropertyHolder {
-    var properties: MutableList<FPropertyTag>
+    var properties: LinkedHashMap<FName, FPropertyTag>
 }

--- a/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/util/StructFallbackReflectionUtil.kt
+++ b/src/main/kotlin/me/fungames/jfortniteparse/ue4/assets/util/StructFallbackReflectionUtil.kt
@@ -11,6 +11,7 @@ import me.fungames.jfortniteparse.ue4.assets.exports.UClass
 import me.fungames.jfortniteparse.ue4.assets.exports.UObject
 import me.fungames.jfortniteparse.ue4.assets.objects.FPropertyTag
 import me.fungames.jfortniteparse.ue4.assets.objects.IPropertyHolder
+import me.fungames.jfortniteparse.ue4.objects.uobject.FName
 import org.objenesis.ObjenesisStd
 import java.lang.reflect.Array
 import java.lang.reflect.Field
@@ -20,15 +21,15 @@ import java.util.*
 inline fun <reified T> IPropertyHolder.mapToClass() = mapToClass(properties, T::class.java)
 inline fun <T> IPropertyHolder.mapToClass(clazz: Class<T>): T = mapToClass(properties, clazz)
 
-inline fun <T> mapToClass(properties: List<FPropertyTag>, clazz: Class<T>): T = mapToClass(properties, clazz, ObjenesisStd().newInstance(clazz))
-fun <T> mapToClass(properties: List<FPropertyTag>, clazz: Class<T>, obj: T): T {
+inline fun <T> mapToClass(properties: Map<FName, FPropertyTag>, clazz: Class<T>): T = mapToClass(properties, clazz, ObjenesisStd().newInstance(clazz))
+fun <T> mapToClass(properties: Map<FName, FPropertyTag>, clazz: Class<T>, obj: T): T {
     if (properties.isEmpty()) {
         return obj
     }
     try {
         val boundFields = getBoundFields(TypeToken.get(clazz), clazz)
-        for (prop in properties) {
-            val field = boundFields[prop.name.text] ?: continue
+        for ((name, prop) in properties) {
+            val field = boundFields[name.text] ?: continue
             writePropertyToField(prop, field, obj)
         }
         return obj


### PR DESCRIPTION
Though casting UObjects to a class that contains the right fields is a great way to work with them, it is not very practical when working with objects that aren't registered. The ways around it (unless I'm missing something) is

- converting to json, which loses a lot of information
- using the UObject's get / getOrNull methods, which didn't seem to work for me in Java, and it's also not that efficient to loop through all properties until the right one is found
- or registering new classes, that also didn't really work for me and just gave me null every time (probably my fault, but the point still stands)

So I thought it would make sense to turn the properties list into a map with the name as the key to make it easier and better to use when no class is registered for that object. It also doesn't change anything else, especially because using properties.values will grant basically the same thing as it was before